### PR TITLE
chore: update release workflow to skip existing charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,7 @@ jobs:
           helm repo update
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Added the 'skip_existing' option to the chart-releaser action in the release workflow to prevent re-uploading existing charts.